### PR TITLE
Block `mintToTreasury` & `transferUnderlyingTo`

### DIFF
--- a/src/contracts/interfaces/IRwaAToken.sol
+++ b/src/contracts/interfaces/IRwaAToken.sol
@@ -64,7 +64,7 @@ interface IRwaAToken {
   function transferOnLiquidation(address from, address to, uint256 value) external;
 
   /**
-   * @notice Transfers are not supported for RWA aTokens.
+   * @notice Transfers of the underlying asset are not supported for RWA aTokens.
    * @dev Reverts if called.
    */
   function transferUnderlyingTo(address target, uint256 amount) external;

--- a/src/contracts/interfaces/IRwaAToken.sol
+++ b/src/contracts/interfaces/IRwaAToken.sol
@@ -52,6 +52,12 @@ interface IRwaAToken {
   function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
 
   /**
+   * @notice Not supported for RWA aTokens.
+   * @dev Reverts if called.
+   */
+  function mintToTreasury(uint256 amount, uint256 index) external;
+
+  /**
    * @notice Transfers are not supported in liquidations.
    * @dev Reverts if called.
    */

--- a/src/contracts/interfaces/IRwaAToken.sol
+++ b/src/contracts/interfaces/IRwaAToken.sol
@@ -64,6 +64,12 @@ interface IRwaAToken {
   function transferOnLiquidation(address from, address to, uint256 value) external;
 
   /**
+   * @notice Transfers are not supported for RWA aTokens.
+   * @dev Reverts if called.
+   */
+  function transferUnderlyingTo(address target, uint256 amount) external;
+
+  /**
    * @notice Transfers an amount of aTokens between two users.
    * @dev It checks for valid HF after the tranfer.
    * @dev Only callable by transfer role admin.

--- a/src/contracts/protocol/tokenization/RwaAToken.sol
+++ b/src/contracts/protocol/tokenization/RwaAToken.sol
@@ -86,6 +86,14 @@ abstract contract RwaAToken is AToken, IRwaAToken {
   }
 
   /// @inheritdoc IRwaAToken
+  function mintToTreasury(
+    uint256 amount,
+    uint256 index
+  ) external virtual override(AToken, IRwaAToken) {
+    revert(Errors.OPERATION_NOT_SUPPORTED);
+  }
+
+  /// @inheritdoc IRwaAToken
   function transferOnLiquidation(
     address from,
     address to,

--- a/src/contracts/protocol/tokenization/RwaAToken.sol
+++ b/src/contracts/protocol/tokenization/RwaAToken.sol
@@ -103,6 +103,14 @@ abstract contract RwaAToken is AToken, IRwaAToken {
   }
 
   /// @inheritdoc IRwaAToken
+  function transferUnderlyingTo(
+    address target,
+    uint256 amount
+  ) external virtual override(AToken, IRwaAToken) {
+    revert(Errors.OPERATION_NOT_SUPPORTED);
+  }
+
+  /// @inheritdoc IRwaAToken
   function authorizedTransfer(
     address from,
     address to,

--- a/tests/mocks/AaveV3TestListing.sol
+++ b/tests/mocks/AaveV3TestListing.sol
@@ -36,6 +36,9 @@ contract AaveV3TestListing is AaveV3Payload {
   address public immutable WTGXX_ADDRESS;
   address public immutable WTGXX_MOCK_PRICE_FEED;
 
+  address public immutable BORROWABLE_BUIDL_ADDRESS;
+  address public immutable BORROWABLE_BUIDL_MOCK_PRICE_FEED;
+
   address public immutable GHO_ADDRESS;
   address public immutable GHO_MOCK_PRICE_FEED;
 
@@ -63,6 +66,11 @@ contract AaveV3TestListing is AaveV3Payload {
 
     BUIDL_ADDRESS = address(new TestnetRWAERC20('BUIDL', 'BUIDL', 6, erc20Owner));
     BUIDL_MOCK_PRICE_FEED = address(new MockAggregator(1e8));
+
+    BORROWABLE_BUIDL_ADDRESS = address(
+      new TestnetRWAERC20('BORROWABLE_BUIDL', 'BORROWABLE_BUIDL', 6, erc20Owner)
+    );
+    BORROWABLE_BUIDL_MOCK_PRICE_FEED = address(new MockAggregator(1e8));
 
     USTB_ADDRESS = address(new TestnetRWAERC20('USTB', 'USTB', 6, erc20Owner));
     USTB_MOCK_PRICE_FEED = address(new MockAggregator(10e8));
@@ -134,7 +142,7 @@ contract AaveV3TestListing is AaveV3Payload {
     override
     returns (IEngine.ListingWithCustomImpl[] memory)
   {
-    IEngine.ListingWithCustomImpl[] memory listingsCustom = new IEngine.ListingWithCustomImpl[](6);
+    IEngine.ListingWithCustomImpl[] memory listingsCustom = new IEngine.ListingWithCustomImpl[](7);
 
     IEngine.InterestRateInputData memory rateParams = IEngine.InterestRateInputData({
       optimalUsageRatio: 45_00,
@@ -282,6 +290,31 @@ contract AaveV3TestListing is AaveV3Payload {
         liqThreshold: 86_00,
         liqBonus: 5_00,
         reserveFactor: EngineFlags.KEEP_CURRENT,
+        supplyCap: 0,
+        borrowCap: 0,
+        debtCeiling: 0,
+        liqProtocolFee: 0
+      }),
+      IEngine.TokenImplementations({
+        aToken: RWA_ATOKEN_IMPLEMENTATION,
+        vToken: VARIABLE_DEBT_TOKEN_IMPLEMENTATION
+      })
+    );
+
+    listingsCustom[6] = IEngine.ListingWithCustomImpl(
+      IEngine.Listing({
+        asset: BORROWABLE_BUIDL_ADDRESS,
+        assetSymbol: 'BORROWABLE_BUIDL',
+        priceFeed: BORROWABLE_BUIDL_MOCK_PRICE_FEED,
+        rateStrategyParams: rateParams,
+        enabledToBorrow: EngineFlags.ENABLED,
+        borrowableInIsolation: EngineFlags.ENABLED,
+        withSiloedBorrowing: EngineFlags.DISABLED,
+        flashloanable: EngineFlags.DISABLED,
+        ltv: 82_50,
+        liqThreshold: 86_00,
+        liqBonus: 5_00,
+        reserveFactor: 10_00,
         supplyCap: 0,
         borrowCap: 0,
         debtCeiling: 0,

--- a/tests/mocks/AaveV3TestListing.sol
+++ b/tests/mocks/AaveV3TestListing.sol
@@ -36,9 +36,6 @@ contract AaveV3TestListing is AaveV3Payload {
   address public immutable WTGXX_ADDRESS;
   address public immutable WTGXX_MOCK_PRICE_FEED;
 
-  address public immutable BORROWABLE_BUIDL_ADDRESS;
-  address public immutable BORROWABLE_BUIDL_MOCK_PRICE_FEED;
-
   address public immutable GHO_ADDRESS;
   address public immutable GHO_MOCK_PRICE_FEED;
 
@@ -66,11 +63,6 @@ contract AaveV3TestListing is AaveV3Payload {
 
     BUIDL_ADDRESS = address(new TestnetRWAERC20('BUIDL', 'BUIDL', 6, erc20Owner));
     BUIDL_MOCK_PRICE_FEED = address(new MockAggregator(1e8));
-
-    BORROWABLE_BUIDL_ADDRESS = address(
-      new TestnetRWAERC20('BORROWABLE_BUIDL', 'BORROWABLE_BUIDL', 6, erc20Owner)
-    );
-    BORROWABLE_BUIDL_MOCK_PRICE_FEED = address(new MockAggregator(1e8));
 
     USTB_ADDRESS = address(new TestnetRWAERC20('USTB', 'USTB', 6, erc20Owner));
     USTB_MOCK_PRICE_FEED = address(new MockAggregator(10e8));
@@ -142,7 +134,7 @@ contract AaveV3TestListing is AaveV3Payload {
     override
     returns (IEngine.ListingWithCustomImpl[] memory)
   {
-    IEngine.ListingWithCustomImpl[] memory listingsCustom = new IEngine.ListingWithCustomImpl[](7);
+    IEngine.ListingWithCustomImpl[] memory listingsCustom = new IEngine.ListingWithCustomImpl[](6);
 
     IEngine.InterestRateInputData memory rateParams = IEngine.InterestRateInputData({
       optimalUsageRatio: 45_00,
@@ -290,31 +282,6 @@ contract AaveV3TestListing is AaveV3Payload {
         liqThreshold: 86_00,
         liqBonus: 5_00,
         reserveFactor: EngineFlags.KEEP_CURRENT,
-        supplyCap: 0,
-        borrowCap: 0,
-        debtCeiling: 0,
-        liqProtocolFee: 0
-      }),
-      IEngine.TokenImplementations({
-        aToken: RWA_ATOKEN_IMPLEMENTATION,
-        vToken: VARIABLE_DEBT_TOKEN_IMPLEMENTATION
-      })
-    );
-
-    listingsCustom[6] = IEngine.ListingWithCustomImpl(
-      IEngine.Listing({
-        asset: BORROWABLE_BUIDL_ADDRESS,
-        assetSymbol: 'BORROWABLE_BUIDL',
-        priceFeed: BORROWABLE_BUIDL_MOCK_PRICE_FEED,
-        rateStrategyParams: rateParams,
-        enabledToBorrow: EngineFlags.ENABLED,
-        borrowableInIsolation: EngineFlags.ENABLED,
-        withSiloedBorrowing: EngineFlags.DISABLED,
-        flashloanable: EngineFlags.DISABLED,
-        ltv: 82_50,
-        liqThreshold: 86_00,
-        liqBonus: 5_00,
-        reserveFactor: 10_00,
         supplyCap: 0,
         borrowCap: 0,
         debtCeiling: 0,

--- a/tests/protocol/pool/Pool.Borrow.Rwa.t.sol
+++ b/tests/protocol/pool/Pool.Borrow.Rwa.t.sol
@@ -29,11 +29,13 @@ contract PoolBorrowRwaTests is TestnetProcedures {
     vm.stopPrank();
   }
 
-  function test_reverts_borrow_TransferUnderlyingTo_OperationNotSupported() public {
+  function test_reverts_fuzz_borrow_TransferUnderlyingTo_OperationNotSupported(
+    uint256 borrowAmount
+  ) public {
+    borrowAmount = bound(borrowAmount, 1, 8_000e6);
+
     vm.prank(bob);
     contracts.poolProxy.supply(tokenList.wbtc, 0.4e8, bob, 0);
-
-    uint256 borrowAmount = 2000e6;
 
     vm.expectCall(
       rwaATokenList.aBuidl,

--- a/tests/protocol/pool/Pool.Borrow.Rwa.t.sol
+++ b/tests/protocol/pool/Pool.Borrow.Rwa.t.sol
@@ -16,7 +16,7 @@ contract PoolBorrowRwaTests is TestnetProcedures {
     _seedLiquidity({token: tokenList.buidl, amount: 50_000e6, isRwa: true});
   }
 
-  function test_reverts_fuzz_borrow_TransferUnderlyingTo_OperationNotSupported(
+  function test_fuzz_reverts_borrow_TransferUnderlyingTo_OperationNotSupported(
     uint256 borrowAmount
   ) public {
     borrowAmount = bound(borrowAmount, 1, 8_000e6);

--- a/tests/protocol/pool/Pool.Borrow.Rwa.t.sol
+++ b/tests/protocol/pool/Pool.Borrow.Rwa.t.sol
@@ -9,24 +9,11 @@ contract PoolBorrowRwaTests is TestnetProcedures {
   function setUp() public {
     initTestEnvironment();
 
-    vm.startPrank(poolAdmin);
     // set buidl borrowing config
+    vm.prank(poolAdmin);
     contracts.poolConfiguratorProxy.setReserveBorrowing(tokenList.buidl, true);
-    // authorize & mint BUIDL to bob
-    buidl.authorize(bob, true);
-    buidl.mint(bob, 100_000e6);
-    // authorize & mint BUIDL to liquidityProvider
-    buidl.authorize(liquidityProvider, true);
-    buidl.mint(liquidityProvider, 100_000e6);
-    vm.stopPrank();
 
-    vm.prank(bob);
-    buidl.approve(report.poolProxy, UINT256_MAX);
-
-    vm.startPrank(liquidityProvider);
-    buidl.approve(report.poolProxy, UINT256_MAX);
-    contracts.poolProxy.supply(tokenList.buidl, 50_000e6, liquidityProvider, 0);
-    vm.stopPrank();
+    _seedLiquidity({token: tokenList.buidl, amount: 50_000e6, isRwa: true});
   }
 
   function test_reverts_fuzz_borrow_TransferUnderlyingTo_OperationNotSupported(

--- a/tests/protocol/pool/Pool.Borrow.Rwa.t.sol
+++ b/tests/protocol/pool/Pool.Borrow.Rwa.t.sol
@@ -33,14 +33,16 @@ contract PoolBorrowRwaTests is TestnetProcedures {
     vm.prank(bob);
     contracts.poolProxy.supply(tokenList.wbtc, 0.4e8, bob, 0);
 
+    uint256 borrowAmount = 2000e6;
+
     vm.expectCall(
       rwaATokenList.aBuidl,
-      abi.encodeCall(IRwaAToken.transferUnderlyingTo, (bob, 2000e6))
+      abi.encodeCall(IRwaAToken.transferUnderlyingTo, (bob, borrowAmount))
     );
 
-    vm.expectRevert(bytes(Errors.OPERATION_NOT_SUPPORTED));
+    vm.expectRevert(bytes(Errors.OPERATION_NOT_SUPPORTED), rwaATokenList.aBuidl);
 
     vm.prank(bob);
-    contracts.poolProxy.borrow(tokenList.buidl, 2000e6, 2, 0, bob);
+    contracts.poolProxy.borrow(tokenList.buidl, borrowAmount, 2, 0, bob);
   }
 }

--- a/tests/protocol/pool/Pool.Borrow.Rwa.t.sol
+++ b/tests/protocol/pool/Pool.Borrow.Rwa.t.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import {Errors} from 'src/contracts/protocol/libraries/helpers/Errors.sol';
+import {IRwaAToken} from 'src/contracts/interfaces/IRwaAToken.sol';
+import {TestnetProcedures} from 'tests/utils/TestnetProcedures.sol';
+
+contract PoolBorrowRwaTests is TestnetProcedures {
+  function setUp() public {
+    initTestEnvironment();
+
+    vm.startPrank(poolAdmin);
+    // set buidl borrowing config
+    contracts.poolConfiguratorProxy.setReserveBorrowing(tokenList.buidl, true);
+    // authorize & mint BUIDL to bob
+    buidl.authorize(bob, true);
+    buidl.mint(bob, 100_000e6);
+    // authorize & mint BUIDL to liquidityProvider
+    buidl.authorize(liquidityProvider, true);
+    buidl.mint(liquidityProvider, 100_000e6);
+    vm.stopPrank();
+
+    vm.prank(bob);
+    buidl.approve(report.poolProxy, UINT256_MAX);
+
+    vm.startPrank(liquidityProvider);
+    buidl.approve(report.poolProxy, UINT256_MAX);
+    contracts.poolProxy.supply(tokenList.buidl, 50_000e6, liquidityProvider, 0);
+    vm.stopPrank();
+  }
+
+  function test_reverts_borrow_TransferUnderlyingTo_OperationNotSupported() public {
+    vm.prank(bob);
+    contracts.poolProxy.supply(tokenList.wbtc, 0.4e8, bob, 0);
+
+    vm.expectCall(
+      rwaATokenList.aBuidl,
+      abi.encodeCall(IRwaAToken.transferUnderlyingTo, (bob, 2000e6))
+    );
+
+    vm.expectRevert(bytes(Errors.OPERATION_NOT_SUPPORTED));
+
+    vm.prank(bob);
+    contracts.poolProxy.borrow(tokenList.buidl, 2000e6, 2, 0, bob);
+  }
+}

--- a/tests/protocol/pool/Pool.FlashLoans.Rwa.t.sol
+++ b/tests/protocol/pool/Pool.FlashLoans.Rwa.t.sol
@@ -50,7 +50,7 @@ contract PoolFlashLoansRwaTests is TestnetProcedures {
     });
   }
 
-  function test_reverts_fuzz_flashLoan_OperationNotSupported(uint256 amount) public {
+  function test_fuzz_reverts_flashLoan_OperationNotSupported(uint256 amount) public {
     amount = bound(amount, 0, IERC20(rwaATokenList.aBuidl).totalSupply());
 
     vm.expectCall(

--- a/tests/protocol/pool/Pool.FlashLoans.Rwa.t.sol
+++ b/tests/protocol/pool/Pool.FlashLoans.Rwa.t.sol
@@ -23,23 +23,11 @@ contract PoolFlashLoansRwaTests is TestnetProcedures {
       IPoolAddressesProvider(report.poolAddressesProvider)
     );
 
-    vm.startPrank(poolAdmin);
     // make BUIDL flashloanable
+    vm.prank(poolAdmin);
     contracts.poolConfiguratorProxy.setReserveFlashLoaning(tokenList.buidl, true);
-    // authorize alice to hold BUIDL
-    buidl.authorize(alice, true);
-    // mint BUIDL to alice
-    buidl.mint(alice, 100_000e6);
-    // authorize liquidityProvider to hold BUIDL
-    buidl.authorize(liquidityProvider, true);
-    // mint BUIDL to liquidityProvider
-    buidl.mint(liquidityProvider, 100_000e6);
-    vm.stopPrank();
 
-    vm.startPrank(liquidityProvider);
-    buidl.approve(report.poolProxy, UINT256_MAX);
-    contracts.poolProxy.supply(tokenList.buidl, 50_000e6, liquidityProvider, 0);
-    vm.stopPrank();
+    _seedLiquidity({token: tokenList.buidl, amount: 50_000e6, isRwa: true});
   }
 
   function test_reverts_flashLoanSimple_OperationNotSupported() public {

--- a/tests/protocol/pool/Pool.Liquidations.Rwa.t.sol
+++ b/tests/protocol/pool/Pool.Liquidations.Rwa.t.sol
@@ -64,7 +64,7 @@ contract PoolLiquidationsRwaTests is TestnetProcedures {
   LiquidationDataProvider internal liquidationDataProvider;
 
   function setUp() public {
-    initTestEnvironment();
+    initTestEnvironment(false);
 
     liquidationDataProvider = new LiquidationDataProvider(
       address(contracts.poolProxy),
@@ -108,12 +108,7 @@ contract PoolLiquidationsRwaTests is TestnetProcedures {
     wtgxx.approve(report.poolProxy, UINT256_MAX);
 
     // supply 100000 USDX such that users can borrow USDX against RWAs
-    vm.prank(poolAdmin);
-    usdx.mint(liquidityProvider, 100_000e6);
-    vm.startPrank(liquidityProvider);
-    usdx.approve(report.poolProxy, UINT256_MAX);
-    contracts.poolProxy.supply(tokenList.usdx, 100_000e6, liquidityProvider, 0);
-    vm.stopPrank();
+    _seedLiquidity({token: tokenList.usdx, amount: 100_000e6, isRwa: false});
 
     vm.prank(buidlLiquidator);
     usdx.approve(report.poolProxy, UINT256_MAX);

--- a/tests/protocol/pool/Pool.Rwa.t.sol
+++ b/tests/protocol/pool/Pool.Rwa.t.sol
@@ -18,15 +18,9 @@ contract PoolRwaTests is TestnetProcedures {
     // set buidl borrowing config
     contracts.poolConfiguratorProxy.setReserveBorrowing(tokenList.buidl, true);
     contracts.poolConfiguratorProxy.setReserveFactor(tokenList.buidl, 10_00);
-    // authorize & mint BUIDL to bob
-    buidl.authorize(bob, true);
-    buidl.mint(bob, 100_000e6);
     vm.stopPrank();
 
-    vm.prank(bob);
-    buidl.approve(report.poolProxy, UINT256_MAX);
-
-    _seedBuidlLiquidity();
+    _seedLiquidity({token: tokenList.buidl, amount: 50_000e6, isRwa: true});
   }
 
   function test_reverts_mintToTreasury() public {
@@ -56,20 +50,6 @@ contract PoolRwaTests is TestnetProcedures {
 
     vm.expectRevert(bytes(Errors.OPERATION_NOT_SUPPORTED));
     contracts.poolProxy.mintToTreasury(assets);
-  }
-
-  function _seedBuidlLiquidity() internal {
-    // authorize & mint BUIDL to liquidityProvider
-    vm.startPrank(poolAdmin);
-    buidl.authorize(liquidityProvider, true);
-    buidl.mint(liquidityProvider, 100_000e6);
-    vm.stopPrank();
-
-    // supply liquidity through liquidityProvider
-    vm.startPrank(liquidityProvider);
-    buidl.approve(report.poolProxy, UINT256_MAX);
-    contracts.poolProxy.supply(tokenList.buidl, 50_000e6, liquidityProvider, 0);
-    vm.stopPrank();
   }
 
   // upgrade aBuidl to the rwa aToken implementation

--- a/tests/protocol/pool/Pool.Rwa.t.sol
+++ b/tests/protocol/pool/Pool.Rwa.t.sol
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import 'forge-std/Test.sol';
+import 'forge-std/StdStorage.sol';
+
+import {IAToken, IERC20} from 'src/contracts/interfaces/IAToken.sol';
+import {IPool, DataTypes} from 'src/contracts/interfaces/IPool.sol';
+import {IPoolAddressesProvider} from 'src/contracts/interfaces/IPoolAddressesProvider.sol';
+import {PoolInstance} from 'src/contracts/instances/PoolInstance.sol';
+import {Errors} from 'src/contracts/protocol/libraries/helpers/Errors.sol';
+import {ReserveConfiguration} from 'src/contracts/protocol/pool/PoolConfigurator.sol';
+import {WadRayMath} from 'src/contracts/protocol/libraries/math/WadRayMath.sol';
+import {IAaveOracle} from 'src/contracts/interfaces/IAaveOracle.sol';
+import {TestnetProcedures} from 'tests/utils/TestnetProcedures.sol';
+
+contract PoolRwaTests is TestnetProcedures {
+  IPool internal pool;
+
+  function setUp() public virtual {
+    initTestEnvironment();
+
+    (address aBorrowableBuidlAddress, , ) = contracts
+      .protocolDataProvider
+      .getReserveTokensAddresses(tokenList.borrowableBuidl);
+
+    vm.startPrank(poolAdmin);
+    // authorize & mint BUIDL to bob
+    borrowableBuidl.authorize(bob, true);
+    borrowableBuidl.mint(bob, 100_000e6);
+    // authorize & mint BUIDL to carol
+    borrowableBuidl.authorize(carol, true);
+    borrowableBuidl.mint(carol, 100_000e6);
+    // authorize aBUIDL to hold BUIDL
+    borrowableBuidl.authorize(aBorrowableBuidlAddress, true);
+    vm.stopPrank();
+
+    vm.prank(bob);
+    borrowableBuidl.approve(report.poolProxy, UINT256_MAX);
+
+    pool = PoolInstance(report.poolProxy);
+  }
+
+  function test_reverts_mintToTreasury() public {
+    (, , address varDebtBorrowableBuidl) = contracts.protocolDataProvider.getReserveTokensAddresses(
+      tokenList.borrowableBuidl
+    );
+
+    _seedBorrowableBuidlLiquidity();
+
+    vm.startPrank(bob);
+    pool.supply(tokenList.wbtc, 0.4e8, bob, 0);
+    pool.borrow(tokenList.borrowableBuidl, 2000e6, 2, 0, bob);
+    vm.warp(block.timestamp + 30 days);
+    pool.repay(tokenList.borrowableBuidl, IERC20(varDebtBorrowableBuidl).balanceOf(bob), 2, bob);
+    vm.stopPrank();
+
+    // distribute fees to treasury
+    address[] memory assets = new address[](1);
+    assets[0] = tokenList.borrowableBuidl;
+
+    vm.expectRevert(bytes(Errors.OPERATION_NOT_SUPPORTED));
+    pool.mintToTreasury(assets);
+  }
+
+  function _seedBorrowableBuidlLiquidity() internal {
+    vm.startPrank(carol);
+    borrowableBuidl.approve(report.poolProxy, UINT256_MAX);
+    pool.supply(tokenList.borrowableBuidl, 50_000e6, carol, 0);
+    vm.stopPrank();
+  }
+}

--- a/tests/protocol/pool/Pool.Rwa.t.sol
+++ b/tests/protocol/pool/Pool.Rwa.t.sol
@@ -38,9 +38,6 @@ contract PoolRwaTests is TestnetProcedures {
     buidl.authorize(aBuidlAddress, true);
     vm.stopPrank();
 
-    vm.prank(bob);
-    buidl.approve(report.poolProxy, UINT256_MAX);
-
     pool = PoolInstance(report.poolProxy);
   }
 
@@ -55,6 +52,7 @@ contract PoolRwaTests is TestnetProcedures {
     pool.supply(tokenList.wbtc, 0.4e8, bob, 0);
     pool.borrow(tokenList.buidl, 2000e6, 2, 0, bob);
     vm.warp(block.timestamp + 30 days);
+    buidl.approve(report.poolProxy, UINT256_MAX);
     pool.repay(tokenList.buidl, IERC20(varDebtBuidl).balanceOf(bob), 2, bob);
     vm.stopPrank();
 

--- a/tests/protocol/pool/Pool.Rwa.t.sol
+++ b/tests/protocol/pool/Pool.Rwa.t.sol
@@ -2,8 +2,29 @@
 pragma solidity ^0.8.0;
 
 import {IERC20Detailed} from 'src/contracts/dependencies/openzeppelin/contracts/IERC20Detailed.sol';
+import {ConfiguratorInputTypes} from 'src/contracts/protocol/libraries/types/ConfiguratorInputTypes.sol';
+import {RwaATokenInstance} from 'src/contracts/instances/RwaATokenInstance.sol';
+import {ATokenInstance} from 'src/contracts/instances/ATokenInstance.sol';
 import {Errors} from 'src/contracts/protocol/libraries/helpers/Errors.sol';
+import {IRwaAToken} from 'src/contracts/interfaces/IRwaAToken.sol';
+import {IPool} from 'src/contracts/interfaces/IPool.sol';
 import {TestnetProcedures} from 'tests/utils/TestnetProcedures.sol';
+
+contract MockATokenInstance is ATokenInstance {
+  constructor(IPool pool) ATokenInstance(pool) {}
+
+  function getRevision() internal pure virtual override returns (uint256) {
+    return 2;
+  }
+}
+
+contract MockRwaATokenInstance is RwaATokenInstance {
+  constructor(IPool pool) RwaATokenInstance(pool) {}
+
+  function getRevision() internal pure virtual override returns (uint256) {
+    return 3;
+  }
+}
 
 contract PoolRwaTests is TestnetProcedures {
   function setUp() public virtual {
@@ -16,17 +37,12 @@ contract PoolRwaTests is TestnetProcedures {
     // authorize & mint BUIDL to bob
     buidl.authorize(bob, true);
     buidl.mint(bob, 100_000e6);
-    // authorize & mint BUIDL to carol
-    buidl.authorize(carol, true);
-    buidl.mint(carol, 100_000e6);
     // authorize & mint BUIDL to liquidityProvider
     buidl.authorize(liquidityProvider, true);
     buidl.mint(liquidityProvider, 100_000e6);
     vm.stopPrank();
 
     vm.prank(bob);
-    buidl.approve(report.poolProxy, UINT256_MAX);
-    vm.prank(carol);
     buidl.approve(report.poolProxy, UINT256_MAX);
 
     vm.startPrank(liquidityProvider);
@@ -36,6 +52,21 @@ contract PoolRwaTests is TestnetProcedures {
   }
 
   function test_reverts_mintToTreasury() public {
+    // upgrade aBuild to the standard aToken implementation, to be able to borrow
+    vm.startPrank(poolAdmin);
+    contracts.poolConfiguratorProxy.updateAToken(
+      ConfiguratorInputTypes.UpdateATokenInput({
+        asset: tokenList.buidl,
+        treasury: report.treasury,
+        incentivesController: report.rewardsControllerProxy,
+        name: 'aBuidl',
+        symbol: 'aBuidl',
+        implementation: address(new MockATokenInstance(IPool(report.poolProxy))),
+        params: abi.encode()
+      })
+    );
+    vm.stopPrank();
+
     (, , address varDebtBuidl) = contracts.protocolDataProvider.getReserveTokensAddresses(
       tokenList.buidl
     );
@@ -50,6 +81,24 @@ contract PoolRwaTests is TestnetProcedures {
     // distribute fees to treasury
     address[] memory assets = new address[](1);
     assets[0] = tokenList.buidl;
+
+    // upgrade aBuild to the rwa aToken implementation, to test that mintToTreasury reverts
+    vm.startPrank(poolAdmin);
+    contracts.poolConfiguratorProxy.updateAToken(
+      ConfiguratorInputTypes.UpdateATokenInput({
+        asset: tokenList.buidl,
+        treasury: report.treasury,
+        incentivesController: report.rewardsControllerProxy,
+        name: 'aBuidl',
+        symbol: 'aBuidl',
+        implementation: address(new MockRwaATokenInstance(IPool(report.poolProxy))),
+        params: abi.encode()
+      })
+    );
+    vm.stopPrank();
+
+    // expect call by matching the selector only
+    vm.expectCall(rwaATokenList.aBuidl, abi.encodeWithSelector(IRwaAToken.mintToTreasury.selector));
 
     vm.expectRevert(bytes(Errors.OPERATION_NOT_SUPPORTED));
     contracts.poolProxy.mintToTreasury(assets);

--- a/tests/protocol/pool/Pool.Supply.Rwa.t.sol
+++ b/tests/protocol/pool/Pool.Supply.Rwa.t.sol
@@ -14,15 +14,6 @@ contract PoolSupplyRwaTests is TestnetProcedures {
   function setUp() public {
     initTestEnvironment();
 
-    vm.startPrank(poolAdmin);
-    // authorize & mint BUIDL to alice
-    buidl.authorize(alice, true);
-    buidl.mint(alice, 100_000e6);
-    vm.stopPrank();
-
-    vm.prank(alice);
-    buidl.approve(report.poolProxy, UINT256_MAX);
-
     aBuidl = IAToken(rwaATokenList.aBuidl);
   }
 

--- a/tests/protocol/pool/Pool.Supply.Rwa.t.sol
+++ b/tests/protocol/pool/Pool.Supply.Rwa.t.sol
@@ -56,6 +56,19 @@ contract PoolSupplyRwaTests is TestnetProcedures {
     contracts.poolProxy.supply(tokenList.buidl, supplyAmount, onBehalfOf, 0);
   }
 
+  // supply fails because user is no longer authrized to hold RWA
+  function test_fuzz_reverts_supply_UnauthorizedRwaAccount(uint256 supplyAmount) public {
+    supplyAmount = bound(supplyAmount, 1, IERC20(tokenList.buidl).balanceOf(alice));
+
+    vm.prank(poolAdmin);
+    buidl.authorize(alice, false);
+
+    vm.expectRevert(bytes('UNAUTHORIZED_RWA_ACCOUNT'));
+
+    vm.prank(alice);
+    contracts.poolProxy.supply(tokenList.buidl, supplyAmount, alice, 0);
+  }
+
   function test_supply_after_collateral_enabled() public {
     test_first_supply();
     uint256 supplyAmount = 2e6;

--- a/tests/protocol/tokenization/RwaATokenAllowance.t.sol
+++ b/tests/protocol/tokenization/RwaATokenAllowance.t.sol
@@ -11,16 +11,6 @@ contract RwaATokenAllowanceTests is TestnetProcedures {
   function setUp() public {
     initTestEnvironment();
     aBuidl = RwaAToken(rwaATokenList.aBuidl);
-
-    vm.startPrank(poolAdmin);
-    // authorize alice to hold BUIDL
-    buidl.authorize(alice, true);
-    // mint BUIDL to alice
-    buidl.mint(alice, 100_000e6);
-    vm.stopPrank();
-
-    vm.prank(alice);
-    buidl.approve(report.poolProxy, UINT256_MAX);
   }
 
   function test_fuzz_reverts_rwaAToken_permit_OperationNotSupported(

--- a/tests/protocol/tokenization/RwaATokenTransfers.t.sol
+++ b/tests/protocol/tokenization/RwaATokenTransfers.t.sol
@@ -14,26 +14,12 @@ contract RwaATokenTransferTests is TestnetProcedures {
     initTestEnvironment();
     aBuidl = RwaAToken(rwaATokenList.aBuidl);
 
-    vm.startPrank(poolAdmin);
-    // authorize alice to hold BUIDL
-    buidl.authorize(alice, true);
-    // mint BUIDL to alice
-    buidl.mint(alice, 100_000e6);
-    // authorize carol to hold BUIDL
-    buidl.authorize(carol, true);
-    // mint BUIDL to carol
-    buidl.mint(carol, 1e6);
-    vm.stopPrank();
-
-    vm.startPrank(alice);
-    buidl.approve(report.poolProxy, UINT256_MAX);
+    vm.prank(alice);
     contracts.poolProxy.supply(tokenList.buidl, 100e6, alice, 0);
     vm.stopPrank();
 
-    vm.startPrank(carol);
-    buidl.approve(report.poolProxy, UINT256_MAX);
+    vm.prank(carol);
     contracts.poolProxy.supply(tokenList.buidl, 1e6, carol, 0);
-    vm.stopPrank();
   }
 
   function test_fuzz_reverts_rwaAToken_transfer_OperationNotSupported(

--- a/tests/utils/TestnetProcedures.sol
+++ b/tests/utils/TestnetProcedures.sol
@@ -75,8 +75,6 @@ contract TestnetProcedures is Test, DeployUtils, FfiUtils, DefaultMarketInput {
 
   Roles internal roleList;
 
-  address internal aclManagerAddress;
-
   TestnetERC20 internal usdx;
   TestnetERC20 internal wbtc;
   TestnetRWAERC20 internal buidl;
@@ -156,8 +154,6 @@ contract TestnetProcedures is Test, DeployUtils, FfiUtils, DefaultMarketInput {
     vm.label(tokenList.buidl, 'BUIDL');
     vm.label(tokenList.ustb, 'USTB');
     vm.label(tokenList.wtgxx, 'WTGXX');
-
-    aclManagerAddress = address(contracts.aclManager);
 
     if (mintUserTokens) {
       // Perform setup of user positions

--- a/tests/utils/TestnetProcedures.sol
+++ b/tests/utils/TestnetProcedures.sol
@@ -159,6 +159,9 @@ contract TestnetProcedures is Test, DeployUtils, FfiUtils, DefaultMarketInput {
       // Perform setup of user positions
       uint256 mintAmount_USDX = 100_000e6;
       uint256 mintAmount_WBTC = 100e8;
+      uint256 mintAmount_BUIDL = 100_000e6;
+      uint256 mintAmount_USTB = 10_000e6;
+      uint256 mintAmount_WTGXX = 100_000e18;
       address[] memory users = new address[](3);
       users[0] = alice;
       users[1] = bob;
@@ -169,12 +172,21 @@ contract TestnetProcedures is Test, DeployUtils, FfiUtils, DefaultMarketInput {
         usdx.mint(users[x], mintAmount_USDX);
         wbtc.mint(users[x], mintAmount_WBTC);
         deal(address(weth), users[x], 100e18);
+        buidl.authorize(users[x], true);
+        buidl.mint(users[x], mintAmount_BUIDL);
+        ustb.authorize(users[x], true);
+        ustb.mint(users[x], mintAmount_USTB);
+        wtgxx.authorize(users[x], true);
+        wtgxx.mint(users[x], mintAmount_WTGXX);
         vm.stopPrank();
 
         vm.startPrank(users[x]);
         usdx.approve(report.poolProxy, UINT256_MAX);
         wbtc.approve(report.poolProxy, UINT256_MAX);
         weth.approve(report.poolProxy, UINT256_MAX);
+        buidl.approve(report.poolProxy, UINT256_MAX);
+        ustb.approve(report.poolProxy, UINT256_MAX);
+        wtgxx.approve(report.poolProxy, UINT256_MAX);
         vm.stopPrank();
       }
     }
@@ -210,6 +222,22 @@ contract TestnetProcedures is Test, DeployUtils, FfiUtils, DefaultMarketInput {
       IRwaAToken(rwaATokenList.aBuidl).AUTHORIZED_ATOKEN_TRANSFER_ROLE(),
       rwaATokenTransferAdmin
     );
+    vm.stopPrank();
+  }
+
+  function _seedLiquidity(address token, uint256 amount, bool isRwa) internal {
+    if (isRwa) {
+      vm.prank(poolAdmin);
+      TestnetRWAERC20(token).authorize(liquidityProvider, true);
+    }
+
+    vm.prank(poolAdmin);
+    TestnetERC20(token).mint(liquidityProvider, amount);
+
+    // supply liquidity through liquidityProvider
+    vm.startPrank(liquidityProvider);
+    IERC20(token).approve(report.poolProxy, UINT256_MAX);
+    contracts.poolProxy.supply(token, amount, liquidityProvider, 0);
     vm.stopPrank();
   }
 

--- a/tests/utils/TestnetProcedures.sol
+++ b/tests/utils/TestnetProcedures.sol
@@ -82,6 +82,7 @@ contract TestnetProcedures is Test, DeployUtils, FfiUtils, DefaultMarketInput {
   TestnetRWAERC20 internal buidl;
   TestnetRWAERC20 internal ustb;
   TestnetRWAERC20 internal wtgxx;
+  TestnetRWAERC20 internal borrowableBuidl;
   WETH9 internal weth;
 
   address internal rwaATokenTransferAdmin;
@@ -94,6 +95,7 @@ contract TestnetProcedures is Test, DeployUtils, FfiUtils, DefaultMarketInput {
     address ustb;
     address wtgxx;
     address gho;
+    address borrowableBuidl;
   }
 
   struct RwaATokenList {
@@ -149,6 +151,7 @@ contract TestnetProcedures is Test, DeployUtils, FfiUtils, DefaultMarketInput {
     ustb = TestnetRWAERC20(tokenList.ustb);
     wtgxx = TestnetRWAERC20(tokenList.wtgxx);
     weth = WETH9(payable(tokenList.weth));
+    borrowableBuidl = TestnetRWAERC20(tokenList.borrowableBuidl);
 
     vm.label(tokenList.usdx, 'USDX');
     vm.label(tokenList.wbtc, 'WBTC');
@@ -156,6 +159,7 @@ contract TestnetProcedures is Test, DeployUtils, FfiUtils, DefaultMarketInput {
     vm.label(tokenList.buidl, 'BUIDL');
     vm.label(tokenList.ustb, 'USTB');
     vm.label(tokenList.wtgxx, 'WTGXX');
+    vm.label(tokenList.borrowableBuidl, 'BBUIDL');
 
     aclManagerAddress = address(contracts.aclManager);
 
@@ -291,6 +295,7 @@ contract TestnetProcedures is Test, DeployUtils, FfiUtils, DefaultMarketInput {
     assetsList.ustb = testnetListingPayload.USTB_ADDRESS();
     assetsList.wtgxx = testnetListingPayload.WTGXX_ADDRESS();
     assetsList.gho = testnetListingPayload.GHO_ADDRESS();
+    assetsList.borrowableBuidl = testnetListingPayload.BORROWABLE_BUIDL_ADDRESS();
 
     ACLManager manager = ACLManager(r.aclManager);
 

--- a/tests/utils/TestnetProcedures.sol
+++ b/tests/utils/TestnetProcedures.sol
@@ -82,7 +82,6 @@ contract TestnetProcedures is Test, DeployUtils, FfiUtils, DefaultMarketInput {
   TestnetRWAERC20 internal buidl;
   TestnetRWAERC20 internal ustb;
   TestnetRWAERC20 internal wtgxx;
-  TestnetRWAERC20 internal borrowableBuidl;
   WETH9 internal weth;
 
   address internal rwaATokenTransferAdmin;
@@ -95,7 +94,6 @@ contract TestnetProcedures is Test, DeployUtils, FfiUtils, DefaultMarketInput {
     address ustb;
     address wtgxx;
     address gho;
-    address borrowableBuidl;
   }
 
   struct RwaATokenList {
@@ -151,7 +149,6 @@ contract TestnetProcedures is Test, DeployUtils, FfiUtils, DefaultMarketInput {
     ustb = TestnetRWAERC20(tokenList.ustb);
     wtgxx = TestnetRWAERC20(tokenList.wtgxx);
     weth = WETH9(payable(tokenList.weth));
-    borrowableBuidl = TestnetRWAERC20(tokenList.borrowableBuidl);
 
     vm.label(tokenList.usdx, 'USDX');
     vm.label(tokenList.wbtc, 'WBTC');
@@ -159,7 +156,6 @@ contract TestnetProcedures is Test, DeployUtils, FfiUtils, DefaultMarketInput {
     vm.label(tokenList.buidl, 'BUIDL');
     vm.label(tokenList.ustb, 'USTB');
     vm.label(tokenList.wtgxx, 'WTGXX');
-    vm.label(tokenList.borrowableBuidl, 'BBUIDL');
 
     aclManagerAddress = address(contracts.aclManager);
 
@@ -295,7 +291,6 @@ contract TestnetProcedures is Test, DeployUtils, FfiUtils, DefaultMarketInput {
     assetsList.ustb = testnetListingPayload.USTB_ADDRESS();
     assetsList.wtgxx = testnetListingPayload.WTGXX_ADDRESS();
     assetsList.gho = testnetListingPayload.GHO_ADDRESS();
-    assetsList.borrowableBuidl = testnetListingPayload.BORROWABLE_BUIDL_ADDRESS();
 
     ACLManager manager = ACLManager(r.aclManager);
 


### PR DESCRIPTION
merge after https://github.com/aave/aave-v3-horizon/pull/1

- block `mintToTreasury`, `transferUnderlyingTo` methods on rwa aToken