### PR TITLE
Audit Fix: documentation updates

### DIFF
--- a/docs/Horizon/Horizon-overview.md
+++ b/docs/Horizon/Horizon-overview.md
@@ -70,7 +70,7 @@ RWA assets can be listed by utilizing a newly developed aToken contract, `RwaATo
 - liquidationBonus: different per asset, >100%
 - reserveFactor: 0
 - supplyCap: different per asset
-- borrowCap: 0
+- borrowCap: 0 (signifies no borrow cap, but cannot be borrowed due to borrowingEnabled set to false)
 - debtCeiling: non-zero if the RWA asset is in isolation
 - liquidationProtocolFee: 0 (must be 0, otherwise liquidations will revert in RwaAToken due to `transferOnLiquidation`)
 

--- a/docs/Horizon/Horizon-overview.md
+++ b/docs/Horizon/Horizon-overview.md
@@ -76,7 +76,7 @@ RWA assets can be listed by utilizing a newly developed aToken contract, `RwaATo
 
 ### Stablecoins / Permissionless Non-RWA Assets (Borrowable Asset)
 
-Stablecoins, or other non-RWA assets, can be supplied permissionlessly to earn yield. However, they will only be able to be borrowed, but disabled as collateral assets (via asset configuration, by setting Liquidation Threshold to 0). Borrowing will be implicitly permissioned because only users that have supplied RWA assets can borrow stablecoins or other permissionless non-RWA assets (except in a potential case [here](#non-allowlisted-account-can-receive-rwaatokens)). 
+Stablecoins, or other non-RWA assets, can be supplied permissionlessly to earn yield. However, they will only be able to be borrowed, but disabled as collateral assets (via asset configuration, by setting Liquidation Threshold to 0). Borrowing will be implicitly permissioned because only users that have supplied RWA assets can borrow stablecoins or other permissionless non-RWA assets (except in a potential edge case described [here](#non-allowlisted-account-can-receive-rwaatokens)). 
 
 All other existing functionality remains unchanged from v3.3. Stablecoins, or other non-RWA assets, will be listed and operate as usual, following the standard process.
 
@@ -97,7 +97,7 @@ All other existing functionality remains unchanged from v3.3. Stablecoins, or ot
 - debtCeiling: 0 (only applies to isolated asset)
 - liquidationProtocolFee: 0 (as it won't apply for a non-collateral asset)
 
-Stablecoins, or other non-RWA permissionless assets, may also be configured as collateral in the future, by setting `liquidationThreshold` above 0. In such case, permissionless supplying and borrowing would also be enabled within the instance.
+Stablecoins, or other non-RWA permissionless assets, may also be configured as collateral in the future, by setting `liquidationThreshold` above `0`. In such case, natively permissionless borrowing would therefore be enabled within the instance.
 
 ## Edge Cases of Note
 
@@ -109,7 +109,7 @@ If a user has a borrow position but loses private keys to their wallet, this pos
 
 #### Assumptions
 
-- `RWA_1_ISSUER` has been granted the role `FLASH_BORROWER_ROLE`. The account will not pay a premium on the flashloan amount loaned.
+- `RWA_1_ISSUER` has been granted `FLASH_BORROWER_ROLE`. The account will not pay a fee on the flashloan amount loaned.
 - `RWA_1_ISSUER` has been granted `AUTHORIZED_TRANSFER_ROLE` in the RwaATokenManager contract for `aRWA_1`.
 - `RWA_1_ISSUER` has an off-chain agreement with `RWA_1` suppliers to migrate supplier lost positions if needed.
 
@@ -193,7 +193,7 @@ By specifying an arbitrary `to` address argument in the `withdraw` function, use
   - if `ALICE` has **not** been allowlisted to hold `RWA_1`, this transaction will revert.
   - if `ALICE` has been allowlisted to hold `RWA_1`, she will receive `50 RWA_1`.
 
-Outcome
+#### Outcome
 
 Assuming `ALICE` has been allowlisted, the following helpful events will be emitted:
 
@@ -235,7 +235,7 @@ Consider the following scenario:
 - `ALICE` executes a `liquidationCall` on `BOB`'s position, and is able to earn all of `BOB`'s seized `100 RWA_1` (which includes the liquidation bonus) by repaying `BOB`'s `120 USDC` debt.
 - `ALICE` receives `100 RWA_1`.
 
-Outcome
+#### Outcome
 
 Multiple events will be emitted involving the `RWA_1` collateral asset, including two `Transfer` events - one from the underlying `RWA_1` token and one from the `aRWA_1` token being burned. 
 

--- a/docs/Horizon/Horizon-overview.md
+++ b/docs/Horizon/Horizon-overview.md
@@ -278,7 +278,7 @@ The Issuer's Transfer Agent must take care to record this officially as a transf
 
 ### Further Configuration
 
-Exact configuration details for eMode, isolated mode, flash loan premiums, and liquidity mining rewards  are in progress.
+Exact configuration details for eMode, isolated mode, flash loan premiums, and liquidity mining rewards are in progress.
 
 ## References
 

--- a/docs/Horizon/Horizon-overview.md
+++ b/docs/Horizon/Horizon-overview.md
@@ -275,7 +275,7 @@ Underlying `RWA_1` Transfer
 event Transfer(address indexed from, address indexed to, uint256 value);
 ```
 
-From the RWA ERC20 Token contract itself, where:
+From the RWA `ERC20` Token contract itself, where:
 - `from` is the `RWA_1` **RwaAToken** address.
   - Note that the emitted `from` address is the **RwaAToken** smart contract rather than `BOB`'s account. 
 - `to` is `ALICE`'s account.

--- a/docs/Horizon/Horizon-overview.md
+++ b/docs/Horizon/Horizon-overview.md
@@ -8,7 +8,7 @@
 
 ## Overview
 
-The Horizon Instance will introduce permissioned (RWA) assets. The Aave Pool will remain the same, except that RWA assets can be used as collateral in order to borrow stablecoins. Permissioning occurs at the asset level, with each RWA Token issuer enforcing asset-specific restrictions directly into their ERC-20 token. The Aave Pool is agnostic to each specific RWA implementation and its asset-level permissioning.
+The Horizon Instance will introduce permissioned (RWA) assets. The Aave Pool will remain the same, except that RWA assets can be used as collateral in order to borrow stablecoins (or other permissionless non-RWA assets). Permissioning occurs at the asset level, with each RWA Token issuer enforcing asset-specific restrictions directly into their ERC-20 token. The Aave Pool is agnostic to each specific RWA implementation and its asset-level permissioning.
 
 From an Issuer perspective, RwaATokens are an extension of the RWA Tokens, which are securities. These RWA-specific aTokens (which are themselves not securities) will simply signify receipt of ownership of the supplied underlying RWA Token, but holders retain control over their RWA Token and can withdraw them as desired within collateralization limits.
 
@@ -16,7 +16,7 @@ However, holding an RwaAToken is purposefully more restrictive than merely holdi
 
 For added security and robustness, a protocol-wide RWA aToken Transfer Admin is also added, allowing Issuers the ability to forcibly transfer RWA aTokens on behalf of end users (without needing approval). These transfers will still enforce collateralization and health factor requirements as in existing Aave peer-to-peer aToken transfers.
 
-As with the standard Aave instance, an asset can be listed in Horizon through the usual configuration process. This instance is primarily aimed at onboarding stablecoins to be borrowed by RWA holders.
+As with the standard Aave instance, an asset can be listed in Horizon through the usual configuration process. This instance is primarily aimed at onboarding stablecoins (or other non-RWA assets) to be borrowed by RWA holders.
 
 ## Implementation
 
@@ -74,11 +74,11 @@ RWA assets can be listed by utilizing a newly developed aToken contract, `RwaATo
 - debtCeiling: non-zero if the RWA asset is in isolation
 - liquidationProtocolFee: 0 (must be 0, otherwise liquidations will revert in RwaAToken due to `transferOnLiquidation`)
 
-### Stablecoins (Borrowable Asset)
+### Stablecoins / Permissionless Non-RWA Assets (Borrowable Asset)
 
-Stablecoins can be supplied permissionlessly to earn yield. However, they will only be able to be borrowed, but disabled as collateral assets (via asset configuration, by setting Liquidation Threshold to 0). Borrowing will be implicitly permissioned because only users that have supplied RWA assets can borrow stablecoins (except in a potential case [here](#non-allowlisted-account-can-receive-rwaatokens)). 
+Stablecoins, or other non-RWA assets, can be supplied permissionlessly to earn yield. However, they will only be able to be borrowed, but disabled as collateral assets (via asset configuration, by setting Liquidation Threshold to 0). Borrowing will be implicitly permissioned because only users that have supplied RWA assets can borrow stablecoins or other permissionless non-RWA assets (except in a potential case [here](#non-allowlisted-account-can-receive-rwaatokens)). 
 
-All other existing functionality remains unchanged from v3.3. Stablecoin assets will be listed and operate as usual, following the standard process.
+All other existing functionality remains unchanged from v3.3. Stablecoins, or other non-RWA assets, will be listed and operate as usual, following the standard process.
 
 #### Reserve Configuration
 
@@ -96,6 +96,8 @@ All other existing functionality remains unchanged from v3.3. Stablecoin assets 
 - borrowCap: different per asset
 - debtCeiling: 0 (only applies to isolated asset)
 - liquidationProtocolFee: 0 (as it won't apply for a non-collateral asset)
+
+Stablecoins, or other non-RWA permissionless assets, may also be configured as collateral in the future, by setting `liquidationThreshold` above 0. In such case, permissionless supplying and borrowing would also be enabled within the instance.
 
 ## Edge Cases of Note
 


### PR DESCRIPTION
- closes https://github.com/StErMi/aave-v3-horizon-review/issues/16: Stablecoins could also be borrowed by non-whitelisted RWA holders
- closes https://github.com/StErMi/aave-v3-horizon-review/issues/15: Improve the description and provide practical example for the "Edge Cases" section of the "Horizon overview"
- closes https://github.com/StErMi/aave-v3-horizon-review/issues/14: "coordinated liquidation" could create bad debt and deficit
- closes https://github.com/StErMi/aave-v3-horizon-review/issues/12: Minor natspec/documentation issue/typos/improvements
- closes https://github.com/StErMi/aave-v3-horizon-review/issues/10: RwaAToken.authorizedTransfer does not validate if from or to is a blacklisted RWA user
- closes https://github.com/StErMi/aave-v3-horizon-review/issues/8: Consider preventing the ATOKEN_ADMIN_ROLE to "steal" tokens from the configured treasury
- closes https://github.com/StErMi/aave-v3-horizon-review/issues/4: AAVE should enhance the documentation relative to the configuration of RWA, Stable Coins and Pool
- closes https://github.com/StErMi/aave-v3-horizon-review/issues/2: https://github.com/StErMi/aave-v3-horizon-review/issues/2